### PR TITLE
Made getStreams public

### DIFF
--- a/src/ritero/SDK/TwitchTV/TwitchSDK.php
+++ b/src/ritero/SDK/TwitchTV/TwitchSDK.php
@@ -573,7 +573,7 @@ class TwitchSDK
      * @param   boolean
      * @return  stdClass
      */
-    private function getStreams($game = null, $limit = null, $offset = null, $channels = null, $embeddable = null, $hls = null)
+    public function getStreams($game = null, $limit = null, $offset = null, $channels = null, $embeddable = null, $hls = null)
     {
         $params = array(
             'game' => $game,


### PR DESCRIPTION
I think it's good to have wrappers for common uses cases of this method, but sometimes they are not sufficient. For such cases, users of the library should be able to invoke this method directly.
