### PR TITLE
Added client-id header to all requests.

### DIFF
--- a/src/jofner/SDK/TwitchTV/TwitchRequest.php
+++ b/src/jofner/SDK/TwitchTV/TwitchRequest.php
@@ -47,6 +47,15 @@ class TwitchRequest
     const MIME_TYPE = 'application/vnd.twitchtv.v%d+json';
 
     /**
+     * TwitchRequest constructor
+     * @param array $config
+     */
+    public function __construct($config)
+    {
+        $this->config = $config;
+    }
+
+    /**
      * Set the API version to use
      * @param integer $version
      * @deprecated will be removed, force to use v3 API, which is current stable Twitch API version
@@ -114,7 +123,7 @@ class TwitchRequest
         curl_setopt($crl, CURLOPT_CONNECTTIMEOUT, $this->connectTimeout);
         curl_setopt($crl, CURLOPT_TIMEOUT, $this->timeout);
         curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($crl, CURLOPT_HTTPHEADER, array('Expect:', 'Accept: ' . sprintf(self::MIME_TYPE, $this->getApiVersion())));
+        curl_setopt($crl, CURLOPT_HTTPHEADER, array('Expect:', 'Accept: ' . sprintf(self::MIME_TYPE, $this->getApiVersion()), 'Client-ID: ' . $this->config['client_id']));
         curl_setopt($crl, CURLOPT_HEADERFUNCTION, array($this, 'getHeader'));
         curl_setopt($crl, CURLOPT_HEADER, false);
 

--- a/src/jofner/SDK/TwitchTV/TwitchSDK.php
+++ b/src/jofner/SDK/TwitchTV/TwitchSDK.php
@@ -35,11 +35,9 @@ class TwitchSDK
             throw new TwitchException('cURL extension is not installed and is required');
         }
 
-        if (count($config) > 0) {
-            $this->setConfig($config);
-        }
+        $this->setConfig($config);
 
-        $this->request = new TwitchRequest;
+        $this->request = new TwitchRequest($config);
         $this->helper = new Helper;
     }
 


### PR DESCRIPTION
In the near future twitch will require a Client-ID for all api requests. I have added a Client-ID header to curl in the generalRequest method. This also means the client_id, client_secret and redirect_uri config variables are now required, at some point the readme should be updated to reflect this. 