### PR TITLE
Follow URI fix

### DIFF
--- a/src/jofner/SDK/TwitchTV/Methods/Follow.php
+++ b/src/jofner/SDK/TwitchTV/Methods/Follow.php
@@ -18,8 +18,8 @@ class Follow
     protected $request;
 
     const URI_CHANNEL_FOLLOWS = 'channels/%s/follows';
-    const URI_USER_FOLLOWS_CHANNEL = '/users/%s/follows/channels';
-    const URI_USER_FOLLOW_RELATION = '/users/%s/follows/channels/%s';
+    const URI_USER_FOLLOWS_CHANNEL = 'users/%s/follows/channels';
+    const URI_USER_FOLLOW_RELATION = 'users/%s/follows/channels/%s';
 
     /**
      * Follow constructor


### PR DESCRIPTION
Follow status was always 404 now. I guess small semantic changes on the Twitch API.
They now did 404 all https://api.twitch.tv/kraken//users/ urls.